### PR TITLE
Missing cordova header in Capacitor app 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,18 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-webengage" version="1.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 	<name>WebEngagePlugin</name>
-
-    <!-- Removed for deprecating cocoapods support -->
-	<!--<dependency id="cordova-plugin-cocoapod-support"/>-->
-
 	<js-module name="WebEngagePlugin" src="www/WebEngagePlugin.js">
 		<clobbers target="webengage" />
 	</js-module>
 
 	<platform name="ios">
-        <!-- Removed for deprecating cocoapods support -->
-		<!--<pod id="WebEngage" />-->
-
 		<config-file parent="/*" target="config.xml">
 			<feature name="WebEngagePlugin">
 				<param name="ios-package" value="WebEngagePlugin" />

--- a/src/ios/WebEngagePlugin.h
+++ b/src/ios/WebEngagePlugin.h
@@ -1,4 +1,5 @@
 #import "AppDelegate+WebEngagePlugin.h"
+#import <Cordova/CDVPlugin.h>
 
 @interface WebEngagePlugin : CDVPlugin<WEGInAppNotificationProtocol>
 


### PR DESCRIPTION
- Explicitly imported CDVPlugin.h in the plugin header as it's not exposed for capacitor build 