### PR TITLE
Prioritize root project variable for supported android sdk versions

### DIFF
--- a/src/android/WebEngagePlugin.gradle
+++ b/src/android/WebEngagePlugin.gradle
@@ -6,11 +6,11 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 33
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 21
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 33
         manifestPlaceholders.io_version = readVersion()
         versionCode 2
         versionName "1.2.0"


### PR DESCRIPTION
Currently, gradle file sets the sdk versions with hardcoded values, giving less control to the project owners controlling the desired sdk versions they are targetting. This fix intends to solve it by checking if these variables are declared in the root project and giving them priority with some fallback version from WE's end.
Prioritize root project variable for supported android sdk versions